### PR TITLE
fix: resolve Docker network subnet exhaustion

### DIFF
--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -40,8 +40,16 @@ FROM nginx:alpine
 # Copy built app from builder stage
 COPY --from=builder /app/apps/app/dist /usr/share/nginx/html
 
-# Copy custom nginx configuration
-COPY --from=builder /app/apps/app/nginx.conf /etc/nginx/nginx.conf
+# Copy template nginx configuration
+COPY --from=builder /app/apps/app/nginx.conf /etc/nginx/nginx.conf.template
 
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+# Create startup script
+RUN echo '#!/bin/sh' > /docker-entrypoint.sh && \
+    echo 'PORT=${PORT:-3000}' >> /docker-entrypoint.sh && \
+    echo 'sed "s/listen 80;/listen $PORT;/g" /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf' >> /docker-entrypoint.sh && \
+    echo 'exec nginx -g "daemon off;"' >> /docker-entrypoint.sh && \
+    chmod +x /docker-entrypoint.sh
+
+ENV PORT=3000
+
+CMD ["/docker-entrypoint.sh"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -3,6 +3,7 @@ services:
     image: ${BACKEND_IMAGE:-ghcr.io/priyabratamo/ytclipper/backend:latest}
     container_name: ytclipper-${CONTAINER_SUFFIX:-default}-backend
     restart: unless-stopped
+    network_mode: host
     env_file:
       - .env
     environment:
@@ -11,13 +12,12 @@ services:
       - LOG_PRETTY=${LOG_PRETTY:-true}
       - API_TIMEOUT=${API_TIMEOUT:-30s}
       - GIN_MODE=${GIN_MODE:-release}
-    ports:
-      - "${BACKEND_PORT:-8080}:8080"
+      - PORT=${BACKEND_PORT:-8080}
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1",
+          "wget --no-verbose --tries=1 --spider http://localhost:${BACKEND_PORT:-8080}/health || exit 1",
         ]
       interval: 30s
       timeout: 10s
@@ -28,16 +28,23 @@ services:
     image: ${FRONTEND_IMAGE:-ghcr.io/priyabratamo/ytclipper/frontend:latest}
     container_name: ytclipper-${CONTAINER_SUFFIX:-default}-app
     restart: unless-stopped
-    ports:
-      - "${FRONTEND_PORT:-3000}:80"
+    network_mode: host
     env_file:
       - .env
+    environment:
+      - PORT=${FRONTEND_PORT:-3000}
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1",
+          "wget --no-verbose --tries=1 --spider http://localhost:${FRONTEND_PORT:-3000}/ || exit 1",
         ]
       interval: 30s
       timeout: 10s
       retries: 3
+
+# Explicitly disable default network creation
+networks:
+  default:
+    external: true
+    name: bridge


### PR DESCRIPTION
- Use host networking instead of bridge networks to avoid subnet conflicts
- Update frontend Dockerfile to use dynamic PORT configuration
- Remove port mapping since containers now use host network
- This fixes the 'all predefined address pools have been fully subnetted' error